### PR TITLE
Add contrast stretch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Run the code by executing `change_detection_map.py` script. It requires two argu
  * `--image_a` or `-a`: The path to the first input image
  * `--image_b` or `-b`: The path to the second input image
 
-There are two further optional arguents:
+There are three further optional arguents:
 
  * `--rgb`: This allows you to control what colour channel each image uses. It expects a string of three characters, either 'a', 'b' or '0'. 'a' represents `--image_a`, 'b' represents `--image_b` and '0' represents an empty channel. The order of these characters need to follow the order you would like them assigned to the Red, Green and Blue channels, in that order.
  * `--bbox`: This allows you to input a bounding box of coordinates to spatially subset an area of interest for the output image. These coordinates must match the input data coordinate system. It expects four coordinates in the order of:
- 1) Minimum longitude
- 2) Maximum longitude 
- 3) Minimum latitude
- 4) Maximum latitude
+  1) Minimum longitude
+  2) Maximum longitude 
+  3) Minimum latitude
+  4) Maximum latitude
+ * `--stretch`: This allows a default 2% percentile contrast stretch to be applied to each image.
 
 Examples:
 

--- a/change_detection_map.py
+++ b/change_detection_map.py
@@ -121,38 +121,66 @@ def img_get_spatial_subset_of_array(
     return clipped
 
 
-def normalise_arrays(array_a: xarray.DataArray, array_b: xarray.DataArray) -> tuple:
+def normalise_arrays(
+    array_a: xarray.DataArray,
+    array_b: xarray.DataArray,
+    percentile_range: list = None,
+    clip: bool = True,
+) -> tuple:
     """
     Return arrays containing data normalised to the maximum range of the combined
-    input arrays
+    input arrays.
+
+    An optional percentile_range argument can be input in order to provide a contrast
+    stretch to the values. This expects a two item list comprising of the minimum
+    percentile and the maximum percentile in that order. For example, `[2, 98]` would
+    result in a 2% contrast stretch.
     """
 
-    # Get data value ranges
-    min_a = array_a.min()
-    max_a = array_a.max()
-    min_b = array_b.min()
-    max_b = array_b.max()
+    # Combine arrays so we can calculate the data percentile of the values in both
+    # arrays
+    combined_array = numpy.concatenate([array_a, array_b])
 
-    # Get the lowest value of the combined arrays
-    if max_a > max_b:
-        range_max = max_a
+    # If there is no percentile clip input, then normalise using the minimum and maximum
+    # values of the combined two datasets
+    if percentile_range is not None:
+
+        # Get minimum and maximum percentiles that have been input
+        percentile_minimum, percentile_maximum = percentile_range
+
+        # Calcualte percentile values from combined array
+        range_min, range_max = numpy.percentile(
+            combined_array, [percentile_minimum, percentile_maximum]
+        )
+
     else:
-        range_max = max_b
 
-    # Get the maximum value of the combined arrays
-    if min_a < min_b:
-        range_min = min_a
-    else:
-        range_min = min_b
-
-    # Calculate the total data range of the two arrays
-    data_range = range_max - range_min
+        # Get minimum and maximum values of the combined array
+        range_min = combined_array.min()
+        range_max = combined_array.max()
 
     # Normalise data
-    array_a_normalised = (array_a - range_min) / data_range
-    array_b_normalised = (array_b - range_min) / data_range
+    array_a_normalised = normalise(array_a, range_min, range_max, clip=clip)
+    array_b_normalised = normalise(array_b, range_min, range_max, clip=clip)
 
     return array_a_normalised, array_b_normalised
+
+
+def normalise(
+    array: xarray.DataArray, min_value: float, max_value: float, clip: bool = True
+) -> xarray.DataArray:
+    """
+    Normalise an input array to a defined minimum and maximum value
+    """
+
+    # Calculate an array or normalised data
+    normalised_array = (array - min_value) / max_value - min_value
+
+    if clip is not None:
+        # Clip values to 0 to 1
+        normalised_array = normalised_array.clip(0.0, 1.0)
+
+    return normalised_array
 
 
 def make_rgb_stack(
@@ -218,7 +246,13 @@ def sort_arrays_into_rgb_order(
     return channel_list
 
 
-def main(img_a_path: str, img_b_path: str, rgb_map_str: str, bbox_list: list = None):
+def main(
+    img_a_path: str,
+    img_b_path: str,
+    rgb_map_str: str,
+    bbox_list: list = None,
+    stretch: bool = False,
+):
     """
     Steps:
         * Read data as arrays
@@ -251,9 +285,14 @@ def main(img_a_path: str, img_b_path: str, rgb_map_str: str, bbox_list: list = N
         img_a_array = img_get_spatial_subset_of_array(img_a_array, *bbox_list)
         img_b_array = img_get_spatial_subset_of_array(img_b_array, *bbox_list)
 
+    if stretch:
+        stretch = [2, 98]
+    else:
+        stretch = None
+
     # Normalise array values by the combined range of values
     img_a_array_normalised, img_b_array_normalised = normalise_arrays(
-        img_a_array, img_b_array
+        img_a_array, img_b_array, stretch
     )
 
     # Create a RGB stack
@@ -272,7 +311,6 @@ if __name__ == "__main__":
         description=helpstring,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-
     parser.add_argument(
         "-a",
         "--image_a",
@@ -288,7 +326,6 @@ if __name__ == "__main__":
         required=True,
         help="Path to second input image",
     )
-
     parser.add_argument(
         "--rgb",
         default="aab",
@@ -298,7 +335,6 @@ if __name__ == "__main__":
             "results in R = --image_a, G = empty and B = --image_b"
         ),
     )
-
     parser.add_argument(
         "--bbox",
         type=float,
@@ -306,7 +342,13 @@ if __name__ == "__main__":
         metavar=("MIN_LON", "MAX_LON", "MIN_LAT", "MAX_LAT"),
         help="Bounding box as four floats: min_lon max_lon min_lat max_lat",
     )
+    parser.add_argument(
+        "--stretch",
+        default=False,
+        action="store_true",
+        help="Flag to apply a 2 percent contrast stretch to the input images",
+    )
 
     cmdline = parser.parse_args()
 
-    main(cmdline.image_a, cmdline.image_b, cmdline.rgb, cmdline.bbox)
+    main(cmdline.image_a, cmdline.image_b, cmdline.rgb, cmdline.bbox, cmdline.stretch)

--- a/change_detection_map.py
+++ b/change_detection_map.py
@@ -122,24 +122,18 @@ def img_get_spatial_subset_of_array(
 
 
 def normalise_arrays(
-    array_a: xarray.DataArray,
-    array_b: xarray.DataArray,
+    array: xarray.DataArray,
     percentile_range: list = None,
     clip: bool = True,
 ) -> tuple:
     """
-    Return arrays containing data normalised to the maximum range of the combined
-    input arrays.
+    Return array containing data normalised to values between 0 to 1.
 
     An optional percentile_range argument can be input in order to provide a contrast
     stretch to the values. This expects a two item list comprising of the minimum
     percentile and the maximum percentile in that order. For example, `[2, 98]` would
     result in a 2% contrast stretch.
     """
-
-    # Combine arrays so we can calculate the data percentile of the values in both
-    # arrays
-    combined_array = numpy.concatenate([array_a, array_b])
 
     # If there is no percentile clip input, then normalise using the minimum and maximum
     # values of the combined two datasets
@@ -149,31 +143,17 @@ def normalise_arrays(
         percentile_minimum, percentile_maximum = percentile_range
 
         # Calcualte percentile values from combined array
-        range_min, range_max = numpy.percentile(
-            combined_array, [percentile_minimum, percentile_maximum]
+        min_value, max_value = numpy.percentile(
+            array, [percentile_minimum, percentile_maximum]
         )
 
     else:
 
         # Get minimum and maximum values of the combined array
-        range_min = combined_array.min()
-        range_max = combined_array.max()
+        min_value = array.min()
+        max_value = array.max()
 
-    # Normalise data
-    array_a_normalised = normalise(array_a, range_min, range_max, clip=clip)
-    array_b_normalised = normalise(array_b, range_min, range_max, clip=clip)
-
-    return array_a_normalised, array_b_normalised
-
-
-def normalise(
-    array: xarray.DataArray, min_value: float, max_value: float, clip: bool = True
-) -> xarray.DataArray:
-    """
-    Normalise an input array to a defined minimum and maximum value
-    """
-
-    # Calculate an array or normalised data
+    # Calculate an array of normalised data
     normalised_array = (array - min_value) / max_value - min_value
 
     if clip is not None:
@@ -290,10 +270,9 @@ def main(
     else:
         stretch = None
 
-    # Normalise array values by the combined range of values
-    img_a_array_normalised, img_b_array_normalised = normalise_arrays(
-        img_a_array, img_b_array, stretch
-    )
+    # Normalise array values
+    img_a_array_normalised = normalise_arrays(img_a_array, stretch)
+    img_b_array_normalised = normalise_arrays(img_b_array, stretch)
 
     # Create a RGB stack
     rgb_array = make_rgb_stack(img_a_array_normalised, img_b_array_normalised, rgb_map)


### PR DESCRIPTION
I have added a `--stretch` input flag. This will apply a 2% clip to the values in each of the input images.

Initial tests improve comparisons between datasets where the overall values are significantly different (I imagine this will be common when comparing different instruments, level 1 uncorrected data, or where clouds exist in images).

Example before stretch:
<img width="640" height="480" alt="no_stretch" src="https://github.com/user-attachments/assets/d4e47e66-09ee-431c-a4ca-5117a9f4933c" />

Example after stretch:
<img width="640" height="480" alt="stretch" src="https://github.com/user-attachments/assets/9332485e-9466-4bb0-98ff-950327a64476" />

This example shows the construction of a dam and increased irrigation.